### PR TITLE
When first installing auto-command filetype errors occur

### DIFF
--- a/lazyvim.json
+++ b/lazyvim.json
@@ -59,7 +59,7 @@
     "lazyvim.plugins.extras.util.startuptime"
   ],
   "news": {
-    "NEWS.md": "7107"
+    "NEWS.md": "7429"
   },
   "version": 7
 }

--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -33,6 +33,9 @@ require("lazy").setup({
     notify = false, -- notify on update. TODO: only on the dashboard, not while opening some random file
   }, -- automatically check for plugin updates
   performance = {
+    cache = {
+      enabled = false,
+    },
     rtp = {
       -- disable some rtp plugins
       disabled_plugins = {


### PR DESCRIPTION
I was setting up IcarusVim and encountered some errors on installation. This is a common Neovim error in version 0.10 and I also encountered this error when setting up LazyVim.

Fix:
I set performance cache to false.

Error occurred on installation.
![image](https://github.com/user-attachments/assets/828329e5-cc5b-4c26-b0be-2cd78d466a90)
